### PR TITLE
Use `stm-containers` instead of `IORef (Map k v)`

### DIFF
--- a/prometheus-client/benchmarks/Main.hs
+++ b/prometheus-client/benchmarks/Main.hs
@@ -4,13 +4,20 @@
 module Main (main) where
 
 import Prometheus
+import GHC.Stack
+
+import Control.DeepSeq
+import qualified Prometheus.Metric.Vector.STM as Vector.STM
+import qualified Prometheus.Metric.Vector as Vector
 
 import Control.Monad
 import Criterion
 import Criterion.Main
 import Data.Foldable (for_)
 import qualified Data.Text as T
+import Data.Text (Text)
 import System.Random
+import Control.Concurrent.Async
 
 withMetric m =
   envWithCleanup
@@ -32,11 +39,13 @@ withHistogram buckets =
 main :: IO ()
 main =
   defaultMain
-    [ benchCounter
-    , benchGauge
-    , benchSummary
-    , benchHistogram
-    , benchExport
+    [ -- benchCounter
+--     , benchGauge
+--     , benchSummary
+--     , benchHistogram
+--     , benchExport
+     benchVector "Vector" Vector.vector Vector.withLabel Vector.getVectorWith
+    , benchVector "Vector.STM" Vector.STM.vector Vector.STM.withLabel Vector.STM.getVectorWith
     ]
 
 
@@ -104,8 +113,6 @@ benchSummaryWithQuantiles q =
 benchSummaryObserve s =
   bench "observe" $ whnfIO (observe s 42)
 
-
-
 -- Histogram benchmarks
 
 
@@ -147,3 +154,34 @@ benchExportHistograms nHistograms =
     setup = replicateM_ nHistograms $ do
       register $ histogram (Info (T.pack $ show nHistograms) "") defaultBuckets
     teardown _ = unregisterAll
+
+benchVector
+    :: (HasCallStack, NFData (vector (Text, Text, Text) Counter))
+    => String
+    -> ((Text, Text, Text) -> Metric Counter -> Metric (vector (Text, Text, Text) Counter))
+    -> (vector (Text, Text, Text) Counter -> (Text, Text, Text) -> (Counter -> IO ()) -> IO ())
+    -> (vector (Text, Text, Text) Counter -> (Counter -> IO Double) -> IO [((Text, Text, Text), Double)])
+    -> Benchmark
+benchVector str mkVector withLabel' getVectorWith' =
+    envWithCleanup (do
+        v <- register $ mkVector ("route", "status_code", "verb") (counter (Info "hits" "The number of hits on this combination of endpoint, status, and verb"))
+        _ <- pure $!! labelCombinations
+        pure v
+        )
+        (\ _ -> unregisterAll)
+        $ \ vec -> do
+
+        bgroup str
+          [ bench "increment all combinations concurrently" $ nfIO $ do
+              forConcurrently_ labelCombinations $ \label -> do
+                  replicateConcurrently_ 100 $ do
+                      replicateM_ 10 $ do
+                          withLabel' vec label incCounter
+          ]
+
+labelCombinations :: [(Text, Text, Text)]
+labelCombinations =  do
+    route <- ["home", "cool", "users", "users/#{id}", "organizations", "organizations/#{id}", "login", "logout", "subscriptions"]
+    statusCode <- ["200", "201", "204", "400", "401", "404", "500"]
+    verb <- ["GET", "POST", "PUT"]
+    pure (route, statusCode, verb)

--- a/prometheus-client/docs/concurrent-vector.md
+++ b/prometheus-client/docs/concurrent-vector.md
@@ -1,0 +1,259 @@
+# Concurrency in the `Vector` type
+
+The `Vector` type in `Prometheus.Metric.Vector` uses an `IORef (Map l (Metric m))`.
+This is a known antipattern for poor performance.
+The proper fix is to use the [`stm-containers`](https://nikita-volkov.github.io/stm-containers/) which allows signifiacntly better concurrent updates to the `Map`.
+
+The problem is that the `Vector` requires a lock on the entire `Map` in order to update a single value.
+Suppose you have 200 threads, each wanting to update the `Map`.
+The first will do `atomicModifyIORef`, which will grab a lock on the map.
+Every other thread is now blocked.
+The first thread will update the label `k0` and put the map back in.
+The next thread will now lock the whole map for label `k1`.
+Rinse and repeat.
+
+With `StmContainers.Map`, the *key* is locked - so there is only contention on specific keys.
+If 200 threads want to update the map, and they all have distinct keys, then this can all happen concurrently without any locking or STM retrying.
+
+# Benchmarks
+
+To understand this behavior, I created a benchmark that would concurrently make many writes to a `Vector`.
+
+To measure impact of concurrency, I am going to iterate this with `-with-rtsopts=-Nx`.
+
+I am using an Intel i9 with 32 cores.
+
+NOTE: Oops. This code is not faithful to Hackage/released code.
+The released code uses `Data.Atomics.atomicModifyIORefCAS`, which avoids the locking and contention.
+However, I'm going to leave the benchmarks here because they're *very* interesting as a way of seeing how `Data.Atomics.atomicModifyIORefCAS` compares to `Data.IORef.atomicModifyIORef'`.
+
+## `-N1`
+
+```
+benchmarking Vector/increment all combinations concurrently
+time                 474.6 ms   (429.8 ms .. 514.9 ms)
+                     0.999 R²   (0.996 R² .. 1.000 R²)
+mean                 511.6 ms   (493.2 ms .. 529.9 ms)
+std dev              21.50 ms   (18.13 ms .. 24.06 ms)
+variance introduced by outliers: 19% (moderately inflated)
+                               
+benchmarking Vector.STM/increment all combinations concurrently
+time                 194.4 ms   (184.5 ms .. 201.0 ms)
+                     0.999 R²   (0.994 R² .. 1.000 R²)
+mean                 202.3 ms   (197.9 ms .. 206.2 ms)
+std dev              5.733 ms   (3.561 ms .. 8.113 ms)
+variance introduced by outliers: 14% (moderately inflated)
+```
+
+In a single threaded context, `stm-containers` is still over twice as fast.
+
+## `-N2`
+
+
+```
+benchmarking Vector/increment all combinations concurrently
+time                 791.9 ms   (780.6 ms .. 800.9 ms)
+                     1.000 R²   (1.000 R² .. 1.000 R²)
+mean                 789.9 ms   (787.3 ms .. 791.3 ms)
+std dev              2.581 ms   (5.418 μs .. 3.169 ms)
+variance introduced by outliers: 19% (moderately inflated)
+                               
+benchmarking Vector.STM/increment all combinations concurrently
+time                 110.8 ms   (108.3 ms .. 113.4 ms)
+                     0.999 R²   (0.997 R² .. 1.000 R²)
+mean                 113.8 ms   (112.3 ms .. 115.4 ms)
+std dev              2.452 ms   (1.767 ms .. 3.111 ms)
+variance introduced by outliers: 11% (moderately inflated)
+```
+
+With two threads, the normal vector encounters contention and becomes significantly slower (1.6x more time).
+Meanwhile, the STM vector takes 56% the time.
+
+## `-N4`
+
+```
+benchmarking Vector/increment all combinations concurrently
+time                 862.9 ms   (812.8 ms .. 918.9 ms)
+                     0.999 R²   (0.999 R² .. 1.000 R²)
+mean                 849.7 ms   (837.4 ms .. 857.4 ms)
+std dev              12.52 ms   (4.446 ms .. 15.37 ms)
+variance introduced by outliers: 19% (moderately inflated)
+                               
+benchmarking Vector.STM/increment all combinations concurrently
+time                 67.63 ms   (64.95 ms .. 69.86 ms)
+                     0.997 R²   (0.995 R² .. 0.999 R²)
+mean                 65.72 ms   (64.07 ms .. 66.88 ms)
+std dev              2.405 ms   (1.510 ms .. 3.519 ms)
+```
+
+With four threads, contention on the traditional `Vector` is high, and we take even more time - however, it's a modest increase.
+The STM vector improves performance significantly again - taking 57% of the time of using 2 threads.
+
+## `-N8`
+
+```
+benchmarking Vector/increment all combinations concurrently
+time                 1.043 s    (981.4 ms .. 1.099 s)
+                     1.000 R²   (0.998 R² .. 1.000 R²)
+mean                 954.4 ms   (890.9 ms .. 984.0 ms)
+std dev              50.79 ms   (26.11 ms .. 62.92 ms)
+variance introduced by outliers: 19% (moderately inflated)
+                               
+benchmarking Vector.STM/increment all combinations concurrently
+time                 43.53 ms   (42.78 ms .. 44.29 ms)
+                     0.999 R²   (0.997 R² .. 1.000 R²)
+mean                 43.83 ms   (43.26 ms .. 44.58 ms)
+std dev              1.254 ms   (919.2 μs .. 1.745 ms)
+```
+
+The pattern repeats: contention makes the `IORef` vector slower (120% prior time), while more threads makes STM faster (64% of the time).
+
+## `-N16`
+
+```
+benchmarking Vector/increment all combinations concurrently
+time                 2.415 s    (2.019 s .. 2.984 s)
+                     0.994 R²   (0.982 R² .. 1.000 R²)
+mean                 2.603 s    (2.461 s .. 2.805 s)
+std dev              191.8 ms   (71.20 ms .. 244.5 ms)
+variance introduced by outliers: 21% (moderately inflated)
+                               
+benchmarking Vector.STM/increment all combinations concurrently
+time                 44.69 ms   (43.21 ms .. 46.21 ms)
+                     0.998 R²   (0.996 R² .. 0.999 R²)
+mean                 48.07 ms   (46.33 ms .. 51.82 ms)
+std dev              4.928 ms   (1.915 ms .. 7.111 ms)
+variance introduced by outliers: 41% (moderately inflated)
+```
+
+With 16 threads, contention has almost doubled the time on the `IORef`.
+Meanwhile, the `STM` implementation has stabilized around 45ms.
+
+# Oops
+
+At this point, I realize an error that I have made.
+The Hackage version of code uses `Data.Atomics.atomicModifyIORefCAS`, but I have switched it to `atomicModifyIORef'`.
+If I switch it back and rerun, I get significantly better results:
+
+## `-N1`
+
+```
+benchmarking Vector/increment all combinations concurrently
+time                 144.2 ms   (137.9 ms .. 152.0 ms)
+                     0.998 R²   (0.995 R² .. 1.000 R²)
+mean                 141.7 ms   (140.2 ms .. 143.8 ms)
+std dev              2.614 ms   (1.425 ms .. 3.817 ms)
+variance introduced by outliers: 12% (moderately inflated)
+                               
+benchmarking Vector.STM/increment all combinations concurrently
+time                 207.0 ms   (182.7 ms .. 230.8 ms)
+                     0.994 R²   (0.979 R² .. 1.000 R²)
+mean                 203.6 ms   (197.3 ms .. 209.6 ms)
+std dev              8.605 ms   (6.082 ms .. 10.73 ms)
+variance introduced by outliers: 14% (moderately inflated)
+```
+
+With a single threaded implementation, the stock implementation is faster.
+STM is about 33% slower.
+
+## `-N2`
+
+```
+benchmarking Vector/increment all combinations concurrently
+time                 122.5 ms   (120.4 ms .. 124.6 ms)
+                     1.000 R²   (1.000 R² .. 1.000 R²)
+mean                 119.4 ms   (118.1 ms .. 120.5 ms)
+std dev              1.858 ms   (1.325 ms .. 2.617 ms)
+variance introduced by outliers: 11% (moderately inflated)
+                               
+benchmarking Vector.STM/increment all combinations concurrently
+time                 110.9 ms   (104.2 ms .. 116.0 ms)
+                     0.997 R²   (0.995 R² .. 1.000 R²)
+mean                 115.6 ms   (113.3 ms .. 118.4 ms)
+std dev              3.859 ms   (2.682 ms .. 5.249 ms)
+variance introduced by outliers: 11% (moderately inflated)
+```
+
+Stock implementation is slightly faster with two threads. 
+STM implemenation is almost twice as fast, and is now slightly faster.
+
+## `-N4`
+
+```
+benchmarking Vector/increment all combinations concurrently
+time                 99.45 ms   (98.89 ms .. 100.6 ms)
+                     1.000 R²   (1.000 R² .. 1.000 R²)
+mean                 98.95 ms   (98.27 ms .. 99.38 ms)
+std dev              875.4 μs   (576.1 μs .. 1.230 ms)
+                               
+benchmarking Vector.STM/increment all combinations concurrently
+time                 58.75 ms   (57.62 ms .. 59.41 ms)
+                     1.000 R²   (0.999 R² .. 1.000 R²)
+mean                 59.72 ms   (59.11 ms .. 60.80 ms)
+std dev              1.487 ms   (589.8 μs .. 2.436 ms)
+```
+
+With 4 threads, both see significant performance improvements, with STm gaining more of a lead.
+
+## `-N8`
+
+```
+benchmarking Vector/increment all combinations concurrently
+time                 105.3 ms   (104.1 ms .. 108.0 ms)
+                     0.999 R²   (0.998 R² .. 1.000 R²)
+mean                 105.0 ms   (104.0 ms .. 106.1 ms)
+std dev              1.664 ms   (1.196 ms .. 2.480 ms)
+                               
+benchmarking Vector.STM/increment all combinations concurrently
+time                 39.39 ms   (38.23 ms .. 40.39 ms)
+                     0.998 R²   (0.996 R² .. 1.000 R²)
+mean                 40.21 ms   (39.74 ms .. 40.54 ms)
+std dev              780.2 μs   (546.1 μs .. 1.251 ms)
+```
+
+With 8 cores, performance of the `IORef` has stabilized.
+The `STM` implementation continues to improve.
+
+## `-N16`
+
+```
+benchmarking Vector/increment all combinations concurrently
+time                 153.0 ms   (148.8 ms .. 154.1 ms)
+                     1.000 R²   (0.999 R² .. 1.000 R²)
+mean                 152.8 ms   (151.7 ms .. 153.4 ms)
+std dev              1.213 ms   (511.2 μs .. 1.869 ms)
+variance introduced by outliers: 12% (moderately inflated)
+                               
+benchmarking Vector.STM/increment all combinations concurrently
+time                 44.94 ms   (43.59 ms .. 47.01 ms)
+                     0.995 R²   (0.989 R² .. 0.999 R²)
+mean                 45.78 ms   (44.95 ms .. 46.58 ms)
+std dev              1.609 ms   (1.311 ms .. 2.102 ms)
+```
+
+At 16 cores, contention on the IORef increases overhead.
+STM appears stable.
+
+## `-N32`
+
+```
+benchmarking Vector/increment all combinations concurrently
+time                 3.400 s    (654.0 ms .. 4.890 s)
+                     0.921 R²   (NaN R² .. 1.000 R²)
+mean                 3.877 s    (3.432 s .. 4.264 s)
+std dev              457.1 ms   (376.4 ms .. 523.3 ms)
+variance introduced by outliers: 23% (moderately inflated)
+                               
+benchmarking Vector.STM/increment all combinations concurrently
+time                 51.69 ms   (50.44 ms .. 53.48 ms)
+                     0.997 R²   (0.994 R² .. 1.000 R²)
+mean                 52.45 ms   (51.51 ms .. 55.21 ms)
+std dev              2.943 ms   (1.060 ms .. 5.225 ms)
+variance introduced by outliers: 14% (moderately inflated)
+```
+
+With 32 cores, `STM` is constant and even the atomic IORef runs into significant contention.
+
+# Defaults
+
+Based on these observations, this commit changes the default exported in `Prometheus` to the STM vector.

--- a/prometheus-client/docs/memory-use.md
+++ b/prometheus-client/docs/memory-use.md
@@ -89,3 +89,61 @@ A bang pattern on the accumulator can help.
 
 `formatFloat` is used to produce a `Text` label value for the `LabelPair`.
 This suggests we can use `Data.Text.Lazy.Builder` to avoid the intermediate `String`.
+
+# Verifying the Memory Patterns of Various Metrics
+
+## Gauge
+
+A `Gauge` contains an `IORef Double`.
+Operations on the double properly force it to WHNF through the guarantee provided by `atomicModifyIORefCAS_`.
+
+## Counter
+
+Same as Gauge.
+
+## Histogram
+
+Internally a `TVar BucketCounts`, with `BucketCounts` containing a `Double`, `Int`, and `Map Bucket Int`, where `Bucket = Double`.
+
+`withHistogram` uses `modifyTVar'`, which evaluates to WHNF.
+The datatype has strict fields, so this will evaluate all fields of datatype.
+The `Map` comes from `Data.Map.Strict`, which is "strict in the spine" and so this will evaluate the entire `Map` structure.
+
+The `Map` is constructed with a constant set of keys.
+`insert`ing a value into the `Map` does not ever add a key - the relevant `upperBound` is incremented by 1 with a strict operation.
+
+I am still suspicious of `scanl1`. 
+However, we are only calling that on the `Map`, which has fixed number of buckets, and probably a small set of buckets.
+Our app does not use especially large buckets - the term only has ~30 uses in our metrics module, and only ~20 items in the bigger lists.
+
+## Observer
+
+This defines a type class, not a specific method, and gives `observeDuration` helpers.
+Nothing concernig here.
+
+## Summary
+
+`Summary` is an `MVar (ReqSketch (PrimState IO))` and a `[Quantile]`.
+
+### `ReqSketch`
+
+ReqSketch is defined [here](https://www.stackage.org/haddock/lts-23.24/data-sketches-0.3.1.0/DataSketches-Quantiles-RelativeErrorQuantile.html#t:ReqSketch)
+
+## Vector
+
+`Vector` definitely has some sketchy behavior.
+Every time you call `withLabel`, it actually creates a whole new `Metric` unconditionally.
+This is very fast for most `Metric` types.
+However, `Summary` may be more expensive, and we do use a lot of `Summary`.
+
+Using `unsafeInterleaveIO`, we can avoid creating it unless it is actually demanded.
+
+# `atomicModifyIORefCAS`
+
+This function comes from the `atomic-primops` package.
+I don't think it's what we want.
+In a high-contention environment, it is likely to rerun the computation multiple times (up to 30!).
+This means recreating potentially large objects, potentially causing significant extra allocations.
+
+`atomicModifyIORef'` is still not great - we're introducing some contention on the `IORef` for any key.
+An `stm-containers` approach would be better.

--- a/prometheus-client/prometheus-client.cabal
+++ b/prometheus-client/prometheus-client.cabal
@@ -21,6 +21,8 @@ library
   default-language:    Haskell2010
   exposed-modules:
       Prometheus
+    , Prometheus.Metric.Vector.STM
+    , Prometheus.Metric.Vector
   other-modules:
       Prometheus.Info
     , Prometheus.Label
@@ -31,7 +33,6 @@ library
     , Prometheus.Metric.Histogram
     , Prometheus.Metric.Observer
     , Prometheus.Metric.Summary
-    , Prometheus.Metric.Vector
     , Prometheus.MonadMonitor
     , Prometheus.Registry
   build-depends:
@@ -45,6 +46,9 @@ library
     , mtl                >=2
     , stm                >=2.3
     , stm-containers
+    , list-t
+    , focus
+    , hashable
     , transformers
     , transformers-compat
     , utf8-string
@@ -98,10 +102,12 @@ benchmark bench
   main-is:          Main.hs
   build-depends:
       base               >=4.7 && <5
+    , async
     , bytestring
     , criterion          >=1.2
     , prometheus-client
     , random
     , utf8-string
     , text
-  ghc-options: -Wall
+    , deepseq
+  ghc-options: -Wall -O2 -threaded -rtsopts -with-rtsopts=-N32

--- a/prometheus-client/prometheus-client.cabal
+++ b/prometheus-client/prometheus-client.cabal
@@ -44,6 +44,7 @@ library
     , primitive
     , mtl                >=2
     , stm                >=2.3
+    , stm-containers
     , transformers
     , transformers-compat
     , utf8-string

--- a/prometheus-client/src/Prometheus.hs
+++ b/prometheus-client/src/Prometheus.hs
@@ -259,7 +259,7 @@ import Prometheus.Metric.Gauge
 import Prometheus.Metric.Histogram
 import Prometheus.Metric.Observer
 import Prometheus.Metric.Summary
-import Prometheus.Metric.Vector
+import Prometheus.Metric.Vector.STM
 import Prometheus.MonadMonitor
 import Prometheus.Registry
 

--- a/prometheus-client/src/Prometheus/Label.hs
+++ b/prometheus-client/src/Prometheus/Label.hs
@@ -22,6 +22,15 @@ module Prometheus.Label (
 ) where
 
 import Data.Text
+import Data.Hashable
+
+instance (Hashable a, Hashable b, Hashable c, Hashable d, Hashable e, Hashable f, Hashable g, Hashable h) => Hashable (a, b, c, d, e, f, g, h) where
+    hashWithSalt s (a, b, c, d, e, f, g, h) =
+        s `hashWithSalt` a `hashWithSalt` b `hashWithSalt` c `hashWithSalt` d `hashWithSalt` e `hashWithSalt` f `hashWithSalt` g `hashWithSalt` h
+
+instance (Hashable a, Hashable b, Hashable c, Hashable d, Hashable e, Hashable f, Hashable g, Hashable h, Hashable i) => Hashable (a, b, c, d, e, f, g, h, i) where
+    hashWithSalt s (a, b, c, d, e, f, g, h, i) =
+        s `hashWithSalt` a `hashWithSalt` b `hashWithSalt` c `hashWithSalt` d `hashWithSalt` e `hashWithSalt` f `hashWithSalt` g `hashWithSalt` h `hashWithSalt` i
 
 -- | A list of tuples where the first value is the label and the second is the
 -- value of that label.
@@ -34,7 +43,7 @@ data LabelPair = LabelPair { labelKey :: !Text, labelValue :: !Text }
 
 -- | Label describes a class of types that can be used to as the label of
 -- a vector.
-class Ord l => Label l where
+class (Ord l, Hashable l) => Label l where
     labelPairs :: l -> l -> LabelPairs
 
 type Label0 = ()

--- a/prometheus-client/src/Prometheus/Metric/Counter.hs
+++ b/prometheus-client/src/Prometheus/Metric/Counter.hs
@@ -40,7 +40,7 @@ withCounter :: MonadMonitor m
           -> (Double -> Double)
           -> m ()
 withCounter (MkCounter ioref) f =
-    doIO $ Atomics.atomicModifyIORefCAS_ ioref f
+    doIO $ IORef.atomicModifyIORef' ioref (\a -> (f a, ()))
 
 -- | Increments the value of a counter metric by 1.
 incCounter :: MonadMonitor m => Counter -> m ()

--- a/prometheus-client/src/Prometheus/Metric/Gauge.hs
+++ b/prometheus-client/src/Prometheus/Metric/Gauge.hs
@@ -39,7 +39,7 @@ withGauge :: MonadMonitor m
           -> (Double -> Double)
           -> m ()
 withGauge (MkGauge ioref) f =
-    doIO $ Atomics.atomicModifyIORefCAS_ ioref f
+    doIO $ IORef.atomicModifyIORef' ioref (\a -> (f a, ()))
 
 -- | Adds a value to a gauge metric.
 addGauge :: MonadMonitor m => Gauge -> Double -> m ()

--- a/prometheus-client/src/Prometheus/Metric/Summary.hs
+++ b/prometheus-client/src/Prometheus/Metric/Summary.hs
@@ -45,6 +45,7 @@ data Quantile = Quantile
   { quantileRank :: !Rational
   , quantileAcceptableError :: !Rational
   }
+  deriving Show
 
 instance NFData Quantile where
   rnf (Quantile a b) = rnf a `seq` rnf b `seq` ()

--- a/prometheus-client/src/Prometheus/Metric/Vector.hs
+++ b/prometheus-client/src/Prometheus/Metric/Vector.hs
@@ -107,20 +107,17 @@ withLabel (MkVector ioref) label f = doIO $ do
     -- this will only occur if we are actually placing a new metric in the
     -- map.
     --
-    -- Alternative: MVar
+    -- Alternative: stm-containers (implemented in
+    -- Prometheus.Metric.Vector.STM)
     --
-    -- An alternative to this would be using an MVar. The `modifyMVar_`
-    -- function has signature `MVar a -> (a -> IO a) -> IO ()`, and would
-    -- allow us to avoid unsafe IO. One con of this is that consumers would
-    -- be blocked and waiting on the MVar to read.
-    --
-    -- Alternative: stm-containers
-    --
-    -- An `IORef (Map k v)` is a bit of a smell - you must take the entire
-    -- `Map` in order to do any operation, harming concurrent access.
-    -- Instead, an `StmContainers.Map` would allow threads to access
-    -- a single key in `STM`, and only cause transaction aborts or retries
-    -- if the
+    -- An `IORef (Map k v)` is a bit of a smell - you must take a lock on
+    -- the entire `Map` in order to do any operation, harming concurrent
+    -- access. The `atomicModifyIORefCAS` avoids this slightly by allowing
+    -- threads to race the computation, but this is also very wasteful: the
+    -- map must be recomputed on every retry. Instead, an
+    -- `StmContainers.Map` would allow threads to access a single key in
+    -- `STM`, and only cause transaction aborts or retries if there is
+    -- contention on that key.
     newMetric <- unsafeInterleaveIO $ construct gen
     MetricImpl metric _newVectorState <- Atomics.atomicModifyIORefCAS ioref $ \(VectorState _ metricMap) ->
         let (metricToReturn, updatedMap) =

--- a/prometheus-client/src/Prometheus/Metric/Vector.hs
+++ b/prometheus-client/src/Prometheus/Metric/Vector.hs
@@ -13,6 +13,7 @@ import Prometheus.Label
 import Prometheus.Metric
 import Prometheus.MonadMonitor
 
+import System.IO.Unsafe (unsafeInterleaveIO)
 import Control.Applicative ((<$>))
 import Control.DeepSeq
 import qualified Data.Atomics as Atomics
@@ -96,26 +97,57 @@ withLabel :: (Label label, MonadMonitor m)
           -> (metric -> IO ())
           -> m ()
 withLabel (MkVector ioref) label f = doIO $ do
-    VectorState (Metric gen) _ <- IORef.readIORef ioref
-    newMetric <- gen
-    MetricImpl metric newVectorState <- Atomics.atomicModifyIORefCAS ioref $ \(VectorState _ metricMap) ->
-        let maybeMetric = Map.lookup label metricMap
-            updatedMap  = Map.insert label newMetric metricMap
-        in  case maybeMetric of
-                Nothing     -> (VectorState (Metric gen) updatedMap, newMetric)
-                Just metric -> (VectorState (Metric gen) metricMap, metric)
+    VectorState gen _ <- IORef.readIORef ioref
+    -- NOTE: `unsafeInterleaveIO` is used here because we are doing an
+    -- `atomicModifyIORef`. We only conditionally use the `newMetric` if
+    -- the `Map` does not already *have* a metric.
+    --
+    -- Using `unsafeInterleaveIO` will run `gen` lazily, only when the
+    -- `newMetric` is actually demanded. Since we are using `Map.alterF`,
+    -- this will only occur if we are actually placing a new metric in the
+    -- map.
+    --
+    -- Alternative: MVar
+    --
+    -- An alternative to this would be using an MVar. The `modifyMVar_`
+    -- function has signature `MVar a -> (a -> IO a) -> IO ()`, and would
+    -- allow us to avoid unsafe IO. One con of this is that consumers would
+    -- be blocked and waiting on the MVar to read.
+    --
+    -- Alternative: stm-containers
+    --
+    -- An `IORef (Map k v)` is a bit of a smell - you must take the entire
+    -- `Map` in order to do any operation, harming concurrent access.
+    -- Instead, an `StmContainers.Map` would allow threads to access
+    -- a single key in `STM`, and only cause transaction aborts or retries
+    -- if the
+    newMetric <- unsafeInterleaveIO $ construct gen
+    MetricImpl metric _newVectorState <- IORef.atomicModifyIORef' ioref $ \(VectorState _ metricMap) ->
+        let (metricToReturn, updatedMap) =
+                Map.alterF
+                    (\maybeMetric -> case maybeMetric of
+                        Nothing ->
+                            (newMetric, Just newMetric)
+                        Just metric ->
+                            (metric, Just metric)
+                    )
+                    label
+                    metricMap
+        in
+            (VectorState gen updatedMap, metricToReturn)
+
     f metric
 
 -- | Removes a label from a vector.
 removeLabel :: (Label label, MonadMonitor m)
             => Vector label metric -> label -> m ()
 removeLabel (MkVector valueTVar) label =
-    doIO $ Atomics.atomicModifyIORefCAS_ valueTVar f
+    doIO $ IORef.atomicModifyIORef' valueTVar (\a -> (f a, ()))
     where f (VectorState desc metricMap) = VectorState desc (Map.delete label metricMap)
 
 -- | Removes all labels from a vector.
 clearLabels :: (Label label, MonadMonitor m)
             => Vector label metric -> m ()
 clearLabels (MkVector valueTVar) =
-    doIO $ Atomics.atomicModifyIORefCAS_ valueTVar f
+    doIO $ IORef.atomicModifyIORef' valueTVar (\a -> (f a, ()))
     where f (VectorState desc _) = VectorState desc Map.empty

--- a/prometheus-client/src/Prometheus/Metric/Vector/STM.hs
+++ b/prometheus-client/src/Prometheus/Metric/Vector/STM.hs
@@ -102,29 +102,17 @@ withLabel :: (Hashable label, Label label, MonadMonitor m)
           -> (metric -> IO ())
           -> m ()
 withLabel (MkVector (VectorState gen metricMap)) label f = doIO $ do
-    -- NOTE: `unsafeInterleaveIO` is used here because we are doing an
-    -- `atomicModifyIORef`. We only conditionally use the `newMetric` if
-    -- the `Map` does not already *have* a metric.
+    -- NOTE: `unsafeInterleaveIO` will cause `construct gen` to be executed
+    -- and evalauted when `newMetric` is demanded. We will only demand
+    -- `newMetric` in the case that a `Metric` does not already exist in
+    -- the map. This does mean that an IO action will be performed inside
+    -- of an STM transaction. However, due to the nature of
+    -- `unsafeInterleaveIO`, the resulting `newMetric` will be cached and
+    -- reused, so the IO action will not be performed multiple times, even
+    -- if the transaction is invalided and calls `retry`.
     --
-    -- Using `unsafeInterleaveIO` will run `gen` lazily, only when the
-    -- `newMetric` is actually demanded. Since we are using `Map.alterF`,
-    -- this will only occur if we are actually placing a new metric in the
-    -- map.
-    --
-    -- Alternative: MVar
-    --
-    -- An alternative to this would be using an MVar. The `modifyMVar_`
-    -- function has signature `MVar a -> (a -> IO a) -> IO ()`, and would
-    -- allow us to avoid unsafe IO. One con of this is that consumers would
-    -- be blocked and waiting on the MVar to read.
-    --
-    -- Alternative: stm-containers
-    --
-    -- An `IORef (Map k v)` is a bit of a smell - you must take the entire
-    -- `Map` in order to do any operation, harming concurrent access.
-    -- Instead, an `StmContainers.Map` would allow threads to access
-    -- a single key in `STM`, and only cause transaction aborts or retries
-    -- if the
+    -- All instances of `Metric` currently do not perform side-effecting IO
+    -- beyond allocating mutable references. As such, this should be safe.
     newMetric <- unsafeInterleaveIO $ construct gen
     metric' <- atomically $ do
         Map.focus (Focus.alter (\maybeMetric ->

--- a/prometheus-client/src/Prometheus/Metric/Vector/STM.hs
+++ b/prometheus-client/src/Prometheus/Metric/Vector/STM.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE BangPatterns #-}
 
-module Prometheus.Metric.Vector (
+-- | This is a variant of the "Prometheus.Metric.Vector" that uses
+-- @stm-containers@ "StmContainers.Map" instead of an @'IORef' ('Data.Map.Map' k v)@.
+module Prometheus.Metric.Vector.STM (
     Vector (..)
 ,   vector
 ,   withLabel
@@ -13,14 +15,14 @@ import Prometheus.Label
 import Prometheus.Metric
 import Prometheus.MonadMonitor
 
+import Data.Hashable
+import Control.Concurrent.STM (atomically)
 import System.IO.Unsafe (unsafeInterleaveIO)
-import Control.Applicative ((<$>))
 import Control.DeepSeq
-import qualified Data.Atomics as Atomics
-import qualified Data.IORef as IORef
-import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
-import Data.Traversable (forM)
+import qualified StmContainers.Map as Map
+import qualified ListT
+import qualified Focus
 
 
 data VectorState l m = VectorState
@@ -28,7 +30,7 @@ data VectorState l m = VectorState
     , vectorStateMetricMap :: !(Map.Map l (MetricImpl m))
     }
 
-data Vector l m = MkVector (IORef.IORef (VectorState l m))
+newtype Vector l m = MkVector (VectorState l m)
 
 instance NFData (Vector l m) where
   rnf (MkVector ioref) = seq ioref ()
@@ -36,8 +38,9 @@ instance NFData (Vector l m) where
 -- | Creates a new vector of metrics given a label.
 vector :: Label l => l -> Metric m -> Metric (Vector l m)
 vector labels gen = Metric $ do
-    ioref <- checkLabelKeys labels $ IORef.newIORef $ VectorState gen Map.empty
-    return $ MetricImpl (MkVector ioref) (collectVector labels ioref)
+    ms <- Map.newIO
+    let vectorState = checkLabelKeys labels $ VectorState gen ms
+    return $! MetricImpl (MkVector vectorState) (collectVector labels ms)
 
 checkLabelKeys :: Label l => l -> a -> a
 checkLabelKeys keys r = foldl check r $ map (T.unpack . labelKey) $ unLabelPairs $ labelPairs keys keys
@@ -62,10 +65,10 @@ checkLabelKeys keys r = foldl check r $ map (T.unpack . labelKey) $ unLabelPairs
 -- TODO(will): This currently makes the assumption that all the types and info
 -- for all sample groups returned by a metric's collect method will be the same.
 -- It is not clear that this will always be a valid assumption.
-collectVector :: Label l => l -> IORef.IORef (VectorState l m) -> IO [SampleGroup]
-collectVector keys ioref = do
-    VectorState _ metricMap <- IORef.readIORef ioref
-    joinSamples <$> concat <$> mapM collectInner (Map.assocs metricMap)
+collectVector :: Label l => l -> Map.Map l (MetricImpl m) -> IO [SampleGroup]
+collectVector keys metricMap = do
+    assocs <- ListT.toList $ Map.listTNonAtomic metricMap
+    joinSamples <$> concat <$> mapM collectInner assocs
     where
         collectInner (labels, (MetricImpl _metric sampleGroups)) =
             map (adjustSamples labels) <$> sampleGroups
@@ -82,22 +85,23 @@ collectVector keys ioref = do
         extract [] = []
         extract (SampleGroup _ _ s:xs) = s ++ extract xs
 
+getAssocs :: Map.Map k v -> IO [(k, v)]
+getAssocs = ListT.toList . Map.listTNonAtomic
+
 getVectorWith :: Vector label metric
               -> (metric -> IO a)
               -> IO [(label, a)]
-getVectorWith (MkVector valueTVar) f = do
-    VectorState _ metricMap <- IORef.readIORef valueTVar
-    Map.assocs <$> forM metricMap (f . metricImplState)
+getVectorWith (MkVector (VectorState _ metricMap)) f = do
+    traverse (traverse (f . metricImplState)) =<< getAssocs metricMap
 
 -- | Given a label, applies an operation to the corresponding metric in the
 -- vector.
-withLabel :: (Label label, MonadMonitor m)
+withLabel :: (Hashable label, Label label, MonadMonitor m)
           => Vector label metric
           -> label
           -> (metric -> IO ())
           -> m ()
-withLabel (MkVector ioref) label f = doIO $ do
-    VectorState gen _ <- IORef.readIORef ioref
+withLabel (MkVector (VectorState gen metricMap)) label f = doIO $ do
     -- NOTE: `unsafeInterleaveIO` is used here because we are doing an
     -- `atomicModifyIORef`. We only conditionally use the `newMetric` if
     -- the `Map` does not already *have* a metric.
@@ -122,32 +126,27 @@ withLabel (MkVector ioref) label f = doIO $ do
     -- a single key in `STM`, and only cause transaction aborts or retries
     -- if the
     newMetric <- unsafeInterleaveIO $ construct gen
-    MetricImpl metric _newVectorState <- Atomics.atomicModifyIORefCAS ioref $ \(VectorState _ metricMap) ->
-        let (metricToReturn, updatedMap) =
-                Map.alterF
-                    (\maybeMetric -> case maybeMetric of
-                        Nothing ->
-                            (newMetric, Just newMetric)
-                        Just metric ->
-                            (metric, Just metric)
-                    )
-                    label
-                    metricMap
-        in
-            (VectorState gen updatedMap, metricToReturn)
+    metric' <- atomically $ do
+        Map.focus (Focus.alter (\maybeMetric ->
+            case maybeMetric of
+                Nothing ->
+                    Just newMetric
+                Just metric ->
+                    Just metric
+                ) *> Focus.lookupWithDefault newMetric)
+            label
+            metricMap
 
-    f metric
+    f (metricImplState metric')
 
 -- | Removes a label from a vector.
-removeLabel :: (Label label, MonadMonitor m)
+removeLabel :: (Hashable label, Label label, MonadMonitor m)
             => Vector label metric -> label -> m ()
-removeLabel (MkVector valueTVar) label =
-    doIO $ IORef.atomicModifyIORef' valueTVar (\a -> (f a, ()))
-    where f (VectorState desc metricMap) = VectorState desc (Map.delete label metricMap)
+removeLabel (MkVector (VectorState _ metricMap)) label =
+    doIO $ atomically $ Map.delete label metricMap
 
 -- | Removes all labels from a vector.
 clearLabels :: (Label label, MonadMonitor m)
             => Vector label metric -> m ()
-clearLabels (MkVector valueTVar) =
-    doIO $ IORef.atomicModifyIORef' valueTVar (\a -> (f a, ()))
-    where f (VectorState desc _) = VectorState desc Map.empty
+clearLabels (MkVector (VectorState _ metricMap)) =
+    doIO $ atomically $ Map.reset metricMap

--- a/stack.yaml
+++ b/stack.yaml
@@ -6,3 +6,6 @@ packages:
 - prometheus-proc
 - wai-middleware-prometheus
 resolver: lts-22.43
+
+extra-deps:
+  - unix-memory-0.1.2


### PR DESCRIPTION
# Concurrency in the `Vector` type

The `Vector` type in `Prometheus.Metric.Vector` uses an `IORef (Map l (Metric m))`.
This is a known antipattern for poor performance.
The proper fix is to use the [`stm-containers`](https://nikita-volkov.github.io/stm-containers/) which allows signifiacntly better concurrent updates to the `Map`.

The problem is that the `Vector` requires a lock on the entire `Map` in order to update a single value.
Suppose you have 200 threads, each wanting to update the `Map`.
The first will do `atomicModifyIORef`, which will grab a lock on the map.
Every other thread is now blocked.
The first thread will update the label `k0` and put the map back in.
The next thread will now lock the whole map for label `k1`.
Rinse and repeat.

With `StmContainers.Map`, the *key* is locked - so there is only contention on specific keys.
If 200 threads want to update the map, and they all have distinct keys, then this can all happen concurrently without any locking or STM retrying.

# Benchmarks

To understand this behavior, I created a benchmark that would concurrently make many writes to a `Vector`.

To measure impact of concurrency, I am going to iterate this with `-with-rtsopts=-Nx`.

I am using an Intel i9 with 32 cores.

NOTE: Oops. This code is not faithful to Hackage/released code.
The released code uses `Data.Atomics.atomicModifyIORefCAS`, which avoids the locking and contention.
However, I'm going to leave the benchmarks here because they're *very* interesting as a way of seeing how `Data.Atomics.atomicModifyIORefCAS` compares to `Data.IORef.atomicModifyIORef'`.

## `-N1`

```
benchmarking Vector/increment all combinations concurrently
time                 474.6 ms   (429.8 ms .. 514.9 ms)
                     0.999 R²   (0.996 R² .. 1.000 R²)
mean                 511.6 ms   (493.2 ms .. 529.9 ms)
std dev              21.50 ms   (18.13 ms .. 24.06 ms)
variance introduced by outliers: 19% (moderately inflated)
                               
benchmarking Vector.STM/increment all combinations concurrently
time                 194.4 ms   (184.5 ms .. 201.0 ms)
                     0.999 R²   (0.994 R² .. 1.000 R²)
mean                 202.3 ms   (197.9 ms .. 206.2 ms)
std dev              5.733 ms   (3.561 ms .. 8.113 ms)
variance introduced by outliers: 14% (moderately inflated)
```

In a single threaded context, `stm-containers` is still over twice as fast.

## `-N2`


```
benchmarking Vector/increment all combinations concurrently
time                 791.9 ms   (780.6 ms .. 800.9 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 789.9 ms   (787.3 ms .. 791.3 ms)
std dev              2.581 ms   (5.418 μs .. 3.169 ms)
variance introduced by outliers: 19% (moderately inflated)
                               
benchmarking Vector.STM/increment all combinations concurrently
time                 110.8 ms   (108.3 ms .. 113.4 ms)
                     0.999 R²   (0.997 R² .. 1.000 R²)
mean                 113.8 ms   (112.3 ms .. 115.4 ms)
std dev              2.452 ms   (1.767 ms .. 3.111 ms)
variance introduced by outliers: 11% (moderately inflated)
```

With two threads, the normal vector encounters contention and becomes significantly slower (1.6x more time).
Meanwhile, the STM vector takes 56% the time.

## `-N4`

```
benchmarking Vector/increment all combinations concurrently
time                 862.9 ms   (812.8 ms .. 918.9 ms)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 849.7 ms   (837.4 ms .. 857.4 ms)
std dev              12.52 ms   (4.446 ms .. 15.37 ms)
variance introduced by outliers: 19% (moderately inflated)
                               
benchmarking Vector.STM/increment all combinations concurrently
time                 67.63 ms   (64.95 ms .. 69.86 ms)
                     0.997 R²   (0.995 R² .. 0.999 R²)
mean                 65.72 ms   (64.07 ms .. 66.88 ms)
std dev              2.405 ms   (1.510 ms .. 3.519 ms)
```

With four threads, contention on the traditional `Vector` is high, and we take even more time - however, it's a modest increase.
The STM vector improves performance significantly again - taking 57% of the time of using 2 threads.

## `-N8`

```
benchmarking Vector/increment all combinations concurrently
time                 1.043 s    (981.4 ms .. 1.099 s)
                     1.000 R²   (0.998 R² .. 1.000 R²)
mean                 954.4 ms   (890.9 ms .. 984.0 ms)
std dev              50.79 ms   (26.11 ms .. 62.92 ms)
variance introduced by outliers: 19% (moderately inflated)
                               
benchmarking Vector.STM/increment all combinations concurrently
time                 43.53 ms   (42.78 ms .. 44.29 ms)
                     0.999 R²   (0.997 R² .. 1.000 R²)
mean                 43.83 ms   (43.26 ms .. 44.58 ms)
std dev              1.254 ms   (919.2 μs .. 1.745 ms)
```

The pattern repeats: contention makes the `IORef` vector slower (120% prior time), while more threads makes STM faster (64% of the time).

## `-N16`

```
benchmarking Vector/increment all combinations concurrently
time                 2.415 s    (2.019 s .. 2.984 s)
                     0.994 R²   (0.982 R² .. 1.000 R²)
mean                 2.603 s    (2.461 s .. 2.805 s)
std dev              191.8 ms   (71.20 ms .. 244.5 ms)
variance introduced by outliers: 21% (moderately inflated)
                               
benchmarking Vector.STM/increment all combinations concurrently
time                 44.69 ms   (43.21 ms .. 46.21 ms)
                     0.998 R²   (0.996 R² .. 0.999 R²)
mean                 48.07 ms   (46.33 ms .. 51.82 ms)
std dev              4.928 ms   (1.915 ms .. 7.111 ms)
variance introduced by outliers: 41% (moderately inflated)
```

With 16 threads, contention has almost doubled the time on the `IORef`.
Meanwhile, the `STM` implementation has stabilized around 45ms.

# Oops

At this point, I realize an error that I have made.
The Hackage version of code uses `Data.Atomics.atomicModifyIORefCAS`, but I have switched it to `atomicModifyIORef'`.
If I switch it back and rerun, I get significantly better results:

## `-N1`

```
benchmarking Vector/increment all combinations concurrently
time                 144.2 ms   (137.9 ms .. 152.0 ms)
                     0.998 R²   (0.995 R² .. 1.000 R²)
mean                 141.7 ms   (140.2 ms .. 143.8 ms)
std dev              2.614 ms   (1.425 ms .. 3.817 ms)
variance introduced by outliers: 12% (moderately inflated)
                               
benchmarking Vector.STM/increment all combinations concurrently
time                 207.0 ms   (182.7 ms .. 230.8 ms)
                     0.994 R²   (0.979 R² .. 1.000 R²)
mean                 203.6 ms   (197.3 ms .. 209.6 ms)
std dev              8.605 ms   (6.082 ms .. 10.73 ms)
variance introduced by outliers: 14% (moderately inflated)
```

With a single threaded implementation, the stock implementation is faster.
STM is about 33% slower.

## `-N2`

```
benchmarking Vector/increment all combinations concurrently
time                 122.5 ms   (120.4 ms .. 124.6 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 119.4 ms   (118.1 ms .. 120.5 ms)
std dev              1.858 ms   (1.325 ms .. 2.617 ms)
variance introduced by outliers: 11% (moderately inflated)
                               
benchmarking Vector.STM/increment all combinations concurrently
time                 110.9 ms   (104.2 ms .. 116.0 ms)
                     0.997 R²   (0.995 R² .. 1.000 R²)
mean                 115.6 ms   (113.3 ms .. 118.4 ms)
std dev              3.859 ms   (2.682 ms .. 5.249 ms)
variance introduced by outliers: 11% (moderately inflated)
```

Stock implementation is slightly faster with two threads. 
STM implemenation is almost twice as fast, and is now slightly faster.

## `-N4`

```
benchmarking Vector/increment all combinations concurrently
time                 99.45 ms   (98.89 ms .. 100.6 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 98.95 ms   (98.27 ms .. 99.38 ms)
std dev              875.4 μs   (576.1 μs .. 1.230 ms)
                               
benchmarking Vector.STM/increment all combinations concurrently
time                 58.75 ms   (57.62 ms .. 59.41 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 59.72 ms   (59.11 ms .. 60.80 ms)
std dev              1.487 ms   (589.8 μs .. 2.436 ms)
```

With 4 threads, both see significant performance improvements, with STm gaining more of a lead.

## `-N8`

```
benchmarking Vector/increment all combinations concurrently
time                 105.3 ms   (104.1 ms .. 108.0 ms)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 105.0 ms   (104.0 ms .. 106.1 ms)
std dev              1.664 ms   (1.196 ms .. 2.480 ms)
                               
benchmarking Vector.STM/increment all combinations concurrently
time                 39.39 ms   (38.23 ms .. 40.39 ms)
                     0.998 R²   (0.996 R² .. 1.000 R²)
mean                 40.21 ms   (39.74 ms .. 40.54 ms)
std dev              780.2 μs   (546.1 μs .. 1.251 ms)
```

With 8 cores, performance of the `IORef` has stabilized.
The `STM` implementation continues to improve.

## `-N16`

```
benchmarking Vector/increment all combinations concurrently
time                 153.0 ms   (148.8 ms .. 154.1 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 152.8 ms   (151.7 ms .. 153.4 ms)
std dev              1.213 ms   (511.2 μs .. 1.869 ms)
variance introduced by outliers: 12% (moderately inflated)
                               
benchmarking Vector.STM/increment all combinations concurrently
time                 44.94 ms   (43.59 ms .. 47.01 ms)
                     0.995 R²   (0.989 R² .. 0.999 R²)
mean                 45.78 ms   (44.95 ms .. 46.58 ms)
std dev              1.609 ms   (1.311 ms .. 2.102 ms)
```

At 16 cores, contention on the IORef increases overhead.
STM appears stable.

## `-N32`

```
benchmarking Vector/increment all combinations concurrently
time                 3.400 s    (654.0 ms .. 4.890 s)
                     0.921 R²   (NaN R² .. 1.000 R²)
mean                 3.877 s    (3.432 s .. 4.264 s)
std dev              457.1 ms   (376.4 ms .. 523.3 ms)
variance introduced by outliers: 23% (moderately inflated)
                               
benchmarking Vector.STM/increment all combinations concurrently
time                 51.69 ms   (50.44 ms .. 53.48 ms)
                     0.997 R²   (0.994 R² .. 1.000 R²)
mean                 52.45 ms   (51.51 ms .. 55.21 ms)
std dev              2.943 ms   (1.060 ms .. 5.225 ms)
variance introduced by outliers: 14% (moderately inflated)
```

With 32 cores, `STM` is constant and even the atomic IORef runs into significant contention.

# Defaults

Based on these observations, this commit changes the default exported in `Prometheus` to the STM vector.
